### PR TITLE
Add instructions for enabling codegen to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 A VSCode extension that enhances [vscode-java](https://github.com/redhat-developer/vscode-java) and [vscode-kotlin](https://github.com/fwcd/vscode-kotlin) with Java + Kotlin interoperability. This uses a JDT LS extension with a delegate command handler that can work together with the Kotlin Language Server, in order for Java code to have access to Kotlin code.
 
+To use, make sure to have the Kotlin extension installed and to have code generation enabled in your VSCode settings:
+
+```json
+{
+  "kotlin.codegen.enabled": true
+}
+```
+
 **Disclaimer**: This is very experimental, but it seems to work for small maven and gradle projects at least.
 
 ## Features


### PR DESCRIPTION
Sibling PR to

- https://github.com/fwcd/kotlin-language-server/pull/585
- https://github.com/fwcd/vscode-kotlin/pull/157

See the language server PR for a rationale, this explains in the README that code generation has to be enabled explicitly for Java interoperability to work (until we enable it by default again).